### PR TITLE
5회차 - 컴포넌트 구현 패턴

### DIFF
--- a/src/components/List/RestaurantList.tsx
+++ b/src/components/List/RestaurantList.tsx
@@ -1,37 +1,8 @@
 import React, { useState } from 'react';
 import { Restaurant } from '../../interface/restaurant';
 import { useModal } from '../Modal/useModal';
-import { CATEGORY_IMAGE_MAP } from '../../constants/resaurant';
 import RestaurantDetailModal from '../Modal/RestaurantDetailModal';
-
-function RestaurantCard({
-  restaurant,
-  onSelect,
-}: {
-  restaurant: Restaurant;
-  onSelect: (restaurant: Restaurant) => void;
-}) {
-  return (
-    <div
-      className='flex gap-4 px-2 py-4'
-      onClick={() => {
-        onSelect(restaurant);
-      }}
-    >
-      <div className='bg-orange10 flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full'>
-        <img
-          className='h-9 w-9'
-          src={CATEGORY_IMAGE_MAP[restaurant.category]}
-          alt={restaurant.category}
-        />
-      </div>
-      <div className='flex flex-col gap-2'>
-        <h3 className='text-lg font-bold'>{restaurant.name}</h3>
-        <p className='line-clamp-2'>{restaurant.description}</p>
-      </div>
-    </div>
-  );
-}
+import RestaurantCard from '../RestaurantCard';
 
 interface RestaurantListProps {
   restaurants: Restaurant[];
@@ -40,24 +11,48 @@ interface RestaurantListProps {
 export default function RestaurantList({ restaurants }: RestaurantListProps) {
   const { isOpen, openModal, closeModal } = useModal();
   const [selectedRestaurant, setSelectedRestaurant] = useState<Restaurant | null>(null);
+  const [favorites, setFavorites] = useState<Record<string, boolean>>({});
 
   const handleSelectRestaurant = (restaurant: Restaurant) => {
     setSelectedRestaurant(restaurant);
     openModal();
   };
 
+  const handleToggleFavorite = (id: string) => {
+    setFavorites((prev) => ({
+      ...prev,
+      [id]: !prev[id],
+    }));
+  };
+
   return (
-    <div className='divide-gray10 flex h-screen flex-col divide-y overflow-y-auto pb-16'>
-      {/* Restaurant List */}
+    <div className='flex h-screen flex-col divide-y divide-gray-200 overflow-y-auto pb-16'>
+      {/* 레스토랑 목록 */}
       {restaurants.map((restaurant) => (
-        <RestaurantCard
+        <RestaurantCard.Container
           key={restaurant.id}
           restaurant={restaurant}
           onSelect={handleSelectRestaurant}
-        />
+        >
+          <RestaurantCard.CategoryIcon category={restaurant.category} />
+          <div className='flex flex-grow flex-col'>
+            <div className='flex w-full items-start justify-between'>
+              <div className='flex flex-col'>
+                <strong className='text-lg font-bold'>{restaurant.name}</strong>
+                <p className='line-clamp-2'>{restaurant.description}</p>
+              </div>
+              <RestaurantCard.Favorite
+                id={restaurant.id}
+                isFavorite={!!favorites[restaurant.id]}
+                onToggleFavorite={handleToggleFavorite}
+              />
+            </div>
+            <span className='mt-1 text-sm text-orange-500'>{`캠퍼스부터 ${restaurant.distance}분 내`}</span>
+          </div>
+        </RestaurantCard.Container>
       ))}
 
-      {/* Modal */}
+      {/* 모달 */}
       {selectedRestaurant && (
         <RestaurantDetailModal
           isOpen={isOpen}

--- a/src/components/Modal/CreateRestaurantModal.tsx
+++ b/src/components/Modal/CreateRestaurantModal.tsx
@@ -1,8 +1,85 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Modal from './Modal';
 import { Restaurant } from '../../interface/restaurant';
 import Label from '../Form/Label';
-import { useForm } from '../../hooks/useForm';
+import { useMultiStepForm } from '../../hooks/useMultiStepForm';
+
+// 각 스텝별 컴포넌트 정의
+const CategorySection = ({ register, errors }: any) => (
+  <>
+    <Label required htmlFor='category'>
+      카테고리
+    </Label>
+    <select
+      {...register('category')}
+      name='category'
+      className='w-full rounded-md border-2 border-gray-300 p-2'
+    >
+      <option value='한식'>한식</option>
+      <option value='양식'>양식</option>
+      <option value='일식'>일식</option>
+      <option value='중식'>중식</option>
+      <option value='분식'>분식</option>
+      <option value='치킨'>치킨</option>
+    </select>
+    {errors.category && <p className='text-red-500'>{errors.category}</p>}
+
+    <Label required htmlFor='name'>
+      이름
+    </Label>
+    <input
+      {...register('name')}
+      className='w-full rounded-md border-2 border-gray-300 p-2'
+      type='text'
+      name='name'
+    />
+    {errors.name && <p className='text-red-500'>{errors.name}</p>}
+  </>
+);
+
+const DistanceSection = ({ register, errors }: any) => (
+  <>
+    <Label required htmlFor='distance'>
+      거리(도보이동시간)
+    </Label>
+    <select
+      {...register('distance')}
+      name='distance'
+      className='w-full rounded-md border-2 border-gray-300 p-2'
+    >
+      <option value='10'>10분</option>
+      <option value='15'>15분</option>
+      <option value='20'>20분</option>
+      <option value='25'>25분</option>
+      <option value='30'>30분</option>
+    </select>
+    {errors.distance && <p className='text-red-500'>{errors.distance}</p>}
+  </>
+);
+
+const FinalSection = ({ register, errors }: any) => (
+  <>
+    <Label required htmlFor='description'>
+      설명
+    </Label>
+    <textarea
+      {...register('description')}
+      className='w-full rounded-md border-2 border-gray-300 p-2'
+      name='description'
+    />
+    {errors.description && <p className='text-red-500'>{errors.description}</p>}
+
+    <Label htmlFor='link'>참고 링크</Label>
+    <input
+      {...register('link')}
+      placeholder='https://www.example.com'
+      className='w-full rounded-md border-2 border-gray-300 p-2'
+      type='text'
+      name='link'
+    />
+    {errors.link && <p className='text-red-500'>{errors.link}</p>}
+  </>
+);
 
 function CreateRestaurantModal({
   isOpen,
@@ -15,126 +92,100 @@ function CreateRestaurantModal({
   onAddRestaurant: (restaurant: Omit<Restaurant, 'id'>) => Promise<void>;
   isFetching: boolean;
 }) {
-  const { register, handleSubmit, errors, resetForm } = useForm({
-    fields: {
-      name: {
-        required: true,
-        validate: (value: string) =>
-          value.length < 2 ? '이름은 2글자 이상이어야 합니다.' : undefined,
-      },
-      category: {
-        required: true,
-        initialValue: '한식',
-      },
-      description: {
-        required: true,
-        validate: (value) => (value.length < 10 ? '설명은 10글자 이상이어야 합니다.' : undefined),
-      },
-      distance: {
-        required: true,
-      },
-      link: {
-        required: false,
-        validate: (value) => {
-          try {
-            if (value) {
-              new URL(value);
-              return undefined;
-            } else {
-              return undefined;
-            }
-          } catch {
-            return '올바른 URL을 입력해주세요.';
+  const initialValues = {
+    category: '한식',
+    name: '',
+    distance: '10',
+    description: '',
+    link: '',
+  };
+
+  const fields = {
+    name: {
+      required: true,
+      validate: (value: string) =>
+        value.length < 2 ? '이름은 2글자 이상이어야 합니다.' : undefined,
+    },
+    category: {
+      required: true,
+      initialValue: '한식',
+    },
+    description: {
+      required: true,
+      validate: (value) => (value.length < 10 ? '설명은 10글자 이상이어야 합니다.' : undefined),
+    },
+    distance: {
+      required: true,
+    },
+    link: {
+      required: false,
+      validate: (value) => {
+        try {
+          if (value) {
+            new URL(value);
+            return undefined;
           }
-        },
+          return undefined;
+        } catch {
+          return '올바른 URL을 입력해주세요.';
+        }
       },
     },
-    onSubmit: async (values) => {
-      const restaurant = {
-        ...values,
-        distance: Number(values.distance),
-      } as Omit<Restaurant, 'id'>;
-      await onAddRestaurant(restaurant);
-      resetForm();
-      closeModal();
-    },
-  });
+  };
+
+  const { currentStep, register, handleSubmit, errors, nextStep, prevStep, resetMultiStepForm } =
+    useMultiStepForm({
+      steps: 3,
+      initialValues,
+      fields,
+      onSubmit: async (values) => {
+        const restaurant = {
+          ...values,
+          distance: Number(values.distance),
+        } as Omit<Restaurant, 'id'>;
+        await onAddRestaurant(restaurant);
+        resetMultiStepForm();
+        closeModal();
+      },
+    });
+
+  const steps = [
+    <CategorySection register={register} errors={errors} />,
+    <DistanceSection register={register} errors={errors} />,
+    <FinalSection register={register} errors={errors} />,
+  ];
 
   return (
     <Modal isOpen={isOpen} closeModal={closeModal}>
-      <Modal.Title>새로운 음식점</Modal.Title>
+      <Modal.Title>새로운 음식점 ({currentStep + 1}/3)</Modal.Title>
       {errors.form && <p className='text-red-500'>{errors.form}</p>}
       <form className='flex flex-col gap-2' onSubmit={handleSubmit}>
-        <Label required htmlFor='category'>
-          카테고리
-        </Label>
-        <select
-          {...register('category')}
-          name='category'
-          className='w-full rounded-md border-2 border-gray-300 p-2'
-        >
-          <option value='한식'>한식</option>
-          <option value='양식'>양식</option>
-          <option value='일식'>일식</option>
-          <option value='중식'>중식</option>
-          <option value='분식'>분식</option>
-          <option value='치킨'>치킨</option>
-        </select>
-        {errors.category && <p className='text-red-500'>{errors.category}</p>}
-
-        <Label required htmlFor='name'>
-          이름
-        </Label>
-        <input
-          {...register('name')}
-          className='w-full rounded-md border-2 border-gray-300 p-2'
-          type='text'
-          name='name'
-        />
-        {errors.name && <p className='text-red-500'>{errors.name}</p>}
-
-        <Label required htmlFor='distance'>
-          거리(도보이동시간)
-        </Label>
-        <select
-          {...register('distance')}
-          name='distance'
-          className='w-full rounded-md border-2 border-gray-300 p-2'
-        >
-          <option value='10'>10분</option>
-          <option value='15'>15분</option>
-          <option value='20'>20분</option>
-          <option value='25'>25분</option>
-          <option value='30'>30분</option>
-        </select>
-        {errors.distance && <p className='text-red-500'>{errors.distance}</p>}
-
-        <Label required htmlFor='description'>
-          설명
-        </Label>
-        <textarea
-          {...register('description')}
-          className='w-full rounded-md border-2 border-gray-300 p-2'
-          name='description'
-        />
-        {errors.description && <p className='text-red-500'>{errors.description}</p>}
-
-        <Label htmlFor='link'>참고 링크</Label>
-        <input
-          {...register('link')}
-          placeholder='https://www.example.com'
-          className='w-full rounded-md border-2 border-gray-300 p-2'
-          type='text'
-          name='link'
-        />
-        {errors.link && <p className='text-red-500'>{errors.link}</p>}
+        {steps[currentStep]}
         <Modal.Footer>
-          <Modal.Button type='button' colorType='white' onClick={closeModal}>
+          {currentStep > 0 && (
+            <Modal.Button type='button' colorType='white' onClick={prevStep}>
+              이전
+            </Modal.Button>
+          )}
+          <Modal.Button
+            type='button'
+            colorType='white'
+            onClick={() => {
+              resetMultiStepForm();
+              closeModal();
+            }}
+          >
             취소
           </Modal.Button>
-          <Modal.Button type='submit' colorType='orange' disabled={isFetching}>
-            {isFetching ? '추가중...' : '추가'}
-          </Modal.Button>
+          {currentStep === 2 ? (
+            <Modal.Button type='submit' colorType='orange' disabled={isFetching}>
+              {isFetching ? '추가중...' : '추가'}
+            </Modal.Button>
+          ) : (
+            <Modal.Button type='button' colorType='orange' onClick={() => nextStep()}>
+              다음
+            </Modal.Button>
+          )}
         </Modal.Footer>
       </form>
     </Modal>

--- a/src/components/RestaurantCard/CategoryIcon.tsx
+++ b/src/components/RestaurantCard/CategoryIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { CATEGORY_IMAGE_MAP } from '../../constants/resaurant';
+
+interface CategoryIconProps {
+  customIcon?: string;
+  className?: string;
+  category?: string;
+}
+
+/**
+ * 레스토랑 카테고리 아이콘 컴포넌트
+ *
+ * 기본적으로 category에 매핑된 아이콘을 표시하지만,
+ * customIcon prop을 통해 커스텀 아이콘을 설정할 수 있습니다.
+ */
+const CategoryIcon: React.FC<CategoryIconProps> = ({
+  customIcon,
+  className,
+  category = '기타',
+}) => {
+  return (
+    <div
+      className={`flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full bg-orange-200 ${className}`}
+    >
+      <img className='h-9 w-9' src={customIcon || CATEGORY_IMAGE_MAP[category]} alt={category} />
+    </div>
+  );
+};
+
+export default CategoryIcon;

--- a/src/components/RestaurantCard/Favorite.tsx
+++ b/src/components/RestaurantCard/Favorite.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Restaurant } from '../../interface/restaurant';
+
+interface FavoriteProps {
+  id: string;
+  isFavorite: boolean;
+  onToggleFavorite: (id: string) => void;
+}
+
+/**
+ * 즐겨찾기 버튼 컴포넌트
+ *
+ * 레스토랑을 즐겨찾기에 추가/제거할 수 있는 버튼을 제공합니다.
+ * isFavorite 상태에 따라 다른 아이콘을 표시합니다.
+ */
+const Favorite: React.FC<FavoriteProps> = ({ id, isFavorite, onToggleFavorite }) => {
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // 상위 컴포넌트의 클릭 이벤트 전파 방지
+    onToggleFavorite(id);
+  };
+
+  return (
+    <button className='ml-auto' onClick={handleClick}>
+      {isFavorite ? (
+        <svg className='h-6 w-6 fill-current text-orange-500' viewBox='0 0 24 24'>
+          <path d='M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z' />
+        </svg>
+      ) : (
+        <svg
+          className='h-6 w-6 text-gray-400'
+          viewBox='0 0 24 24'
+          stroke='currentColor'
+          strokeWidth='2'
+          fill='none'
+        >
+          <path d='M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z' />
+        </svg>
+      )}
+    </button>
+  );
+};
+
+export default Favorite;

--- a/src/components/RestaurantCard/index.tsx
+++ b/src/components/RestaurantCard/index.tsx
@@ -1,0 +1,43 @@
+import React, { ReactNode, ReactElement } from 'react';
+import CategoryIcon from './CategoryIcon';
+import Favorite from './Favorite';
+import { Restaurant } from '../../interface/restaurant';
+
+// Container 컴포넌트 Props 정의
+interface ContainerProps {
+  restaurant: Restaurant;
+  onSelect: (restaurant: Restaurant) => void;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * RestaurantCard의 Container 컴포넌트
+ *
+ * 다른 모든 RestaurantCard 컴포넌트들은 이 컴포넌트 내부에서 사용되어야 합니다.
+ * React.Children.map을 사용해 자식 컴포넌트에 필요한 props를 전달합니다.
+ */
+const Container: React.FC<ContainerProps> = ({
+  restaurant,
+  onSelect,
+  children,
+  className = '',
+}) => {
+  return (
+    <div className={`flex gap-4 px-2 py-4 ${className}`} onClick={() => onSelect(restaurant)}>
+      {children}
+    </div>
+  );
+};
+
+// 컴파운드 컴포넌트 정의
+const RestaurantCard = {
+  Container,
+  CategoryIcon,
+  Favorite,
+};
+
+export default RestaurantCard;
+
+// 개별 컴포넌트 export
+export { Container, CategoryIcon, Favorite };

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -5,12 +5,14 @@ interface FieldConfig {
   initialValue?: any;
 }
 
-interface FormConfig {
-  fields: Record<string, FieldConfig>;
+export interface ExtendedFieldConfig<T> extends FieldConfig {}
+
+export interface FormConfig<T> {
+  fields: Record<string, ExtendedFieldConfig<T>>;
   onSubmit: (values: Record<string, any>) => Promise<void>;
 }
 
-export function useForm(config: FormConfig) {
+export function useForm<T>(config: FormConfig<T>) {
   const refs = useRef<Record<string, HTMLElement>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
 
@@ -82,7 +84,7 @@ export function useForm(config: FormConfig) {
   };
 
   // useActionState 사용시 오류 발생 ... formData가 안 넘어옴
-  // const [state, formAction, isPending] = useActionState(handleSubmit, {});
+  // const [state, formAction, isPending] = useActionState(handleSubmit, ()=>{});
 
   return {
     register,

--- a/src/hooks/useMultiStepForm.ts
+++ b/src/hooks/useMultiStepForm.ts
@@ -1,0 +1,121 @@
+import { use, useEffect, useState } from 'react';
+import { ExtendedFieldConfig, FormConfig, useForm } from './useForm';
+
+interface useMultiStepFormProps<T> {
+  steps: number;
+  initialValues: T;
+  onSubmit: (values: T) => Promise<void>;
+  fields: Record<string, ExtendedFieldConfig<T>>;
+  initialValue?: T;
+}
+
+export function useMultiStepForm<T>({
+  steps,
+  initialValues,
+  onSubmit,
+  fields,
+}: useMultiStepFormProps<T>) {
+  // 현재 단계 추적
+  const [currentStep, setCurrentStep] = useState(0);
+  // 전체 폼 데이터 유지를 위한 state
+  const [formData, setFormData] = useState<T>(initialValues);
+
+  const { register, handleSubmit, errors, resetForm } = useForm<T>({
+    fields,
+    onSubmit: async (values) => {
+      if (currentStep === steps - 1) {
+        // 최종 제출
+        const finalFormData = {
+          ...formData,
+          ...values,
+        };
+        await onSubmit(finalFormData);
+        // useEFFECT 대신 error 처리 함수 추가
+        resetMultiStepForm();
+      } else {
+        // 중간 단계에서는 현재 데이터를 저장하고 다음으로 이동
+        setFormData((prev) => ({
+          ...prev,
+          ...values,
+        }));
+        setCurrentStep((prev) => prev + 1);
+      }
+    },
+  });
+
+  console.log('errors', errors);
+  // 다음 단계로 이동
+  const nextStep = async () => {
+    // 현재 폼 데이터를 가져와서 저장
+    const formElements = document.forms[0].elements;
+    const currentValues: any = {};
+
+    Object.keys(fields).forEach((fieldName) => {
+      const element = formElements.namedItem(fieldName) as HTMLInputElement;
+      if (element) {
+        currentValues[fieldName] = element.value;
+      }
+    });
+
+    // 현재 데이터 저장
+    setFormData((prev) => ({
+      ...prev,
+      ...currentValues,
+    }));
+
+    if (currentStep < steps - 1) {
+      setCurrentStep((prev) => prev + 1);
+    }
+  };
+
+  // 이전 단계로 이동
+  const prevStep = () => {
+    if (currentStep > 0) {
+      setCurrentStep((prev) => prev - 1);
+    }
+  };
+
+  // 특정 단계로 이동
+  const goToStep = (step: number) => {
+    if (step >= 0 && step < steps) {
+      setCurrentStep(step);
+    }
+  };
+
+  // 폼 초기화
+  const resetMultiStepForm = () => {
+    resetForm();
+    setFormData(initialValues);
+    setCurrentStep(0);
+  };
+
+  // register 함수를 확장하여 저장된 값을 기본값으로 설정
+  const extendedRegister = (name: string) => {
+    const baseRegister = register(name);
+    return {
+      ...baseRegister,
+      defaultValue: formData[name as keyof T] || baseRegister.defaultValue,
+    };
+  };
+
+  useEffect(() => {
+    // errors 처리 해당 에러가 있으면 해당 에러의 Field의 step을 찾아 간다
+    const errorField = Object.keys(errors).find((error) => errors[error]);
+    if (errorField) {
+      const errorFieldIndex = Object.keys(fields).findIndex((field) => field === errorField);
+      setCurrentStep(errorFieldIndex);
+    }
+  }, [errors]);
+
+  return {
+    currentStep,
+    formData,
+    errors,
+    register: extendedRegister,
+    handleSubmit,
+    nextStep,
+    prevStep,
+    goToStep,
+    resetMultiStepForm,
+  };
+}


### PR DESCRIPTION
# 구현 내용 요약
RestaurantCard를 컴파운드 패턴으로 분리하여 Container, CategoryIcon, Favorite 등 독립적 컴포넌트로 구성했으며, 간단한 형태의 카드로Context 대신 명시적 props를 사용해 각 컴포넌트는 필요한 최소 데이터만 받도록 구현 하였습니다. RestaurantList에서는 추상화 레벨을 통일해 컴포넌트 구조를 직관적으로 파악할 수 있게 했습니다.

컴포넌트 구현 패턴에 대한 커밋은 [**여기**](https://github.com/pragmatic-react/pragmatic-react-docs/pull/21/commits/4ead009d9c66929caa846d380ab5a0b65b1537c2) 입니다.

# 설계 원칙 및 구현 기준
<!-- 구현하는 과정에서 고려한 원칙 및 기준 -->
컴파운드 패턴으로 연관 컴포넌트를 유연하게 조합할 수 있게 하고, 동일한 추상화 레벨로 코드 구조를 명확히 했으며, 단일 책임 원칙에 따라 각 컴포넌트는 필요한 최소 데이터만 받아 결합도를 낮추었습니다.

# 학습 자료 및 참고 문서
<!-- 이 UI 구현 시에 참고한 React 설계 원칙에 대한 공식 문서 링크 및 내용 발췌, 추가로 참고한 레퍼런스나 학습 방법이 있다면 나눠주세요 :) -->

# 같이 이야기하고 싶은 내용
실무를 하다보면 재사용 되지 않는 컴포넌트를 너무 분리하여 만들거나,  너무 재사용이나 확장성을 생각하다가 시간을 너무 뺏기는 경우가 있습니다. 이럴때 어떻게 딱 끊으시나요 ?_?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced restaurant listings now offer an interactive favorite toggle, enabling users to mark and manage preferred restaurants.
	- Restaurant cards have been improved with eye-catching category icons and interactive favorite buttons for a better browsing experience.
	- The Create Restaurant modal has been updated to a multi-step form, providing a guided, streamlined process for entering restaurant details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->